### PR TITLE
Fixed format delim

### DIFF
--- a/R/adding_data_fns.R
+++ b/R/adding_data_fns.R
@@ -60,12 +60,12 @@ add_ttl <- function(stardog, ttl = NULL, graph = NULL, path = TRUE) {
 #' @importFrom httr verbose
 #' @export
 add_dataframe <- function(stardog, df, mapping, na = "", graph = NULL,
-                          verbose = FALSE, parallel = TRUE) {
+                          verbose = FALSE, parallel = FALSE) {
   stopifnot(is.data.frame(df))
   if (parallel) {
-    df_io <- readr::format_delim(df, delim = ',', na = na, quote = "all")
+    df_io <- readr::format_delim(df, delim = ',', na = na, quote = "needed")
   } else {
-    df_io <- format_delim_single_thread(df, delim = ',', na = na)
+    df_io <- df_to_string(df)
   }
   input_file_type <- 'DELIMITED'
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -282,6 +282,7 @@ iri_to_prefix <- function(x, stardog) {
 #'
 #' @param x The data frame to be converted
 #' @returns A string serialization of the dataframe
+#'
 df_to_string <- function(x) {
   temp <- as.matrix(x)
   temp[is.na(temp)] <- ""
@@ -289,22 +290,28 @@ df_to_string <- function(x) {
   temp <- apply(temp, 2, fix_punctuation)
   temp <- apply(temp, 1, paste, sep = "", collapse = ',')
   temp <- paste(temp, sep = "", collapse = "\n")
+  temp <- paste(temp, "\n", sep = "")
+  temp <- gsub("trogdor",'\"', temp, fixed=TRUE)
+  temp <- gsub("qu@t&",'\"\"', temp, fixed=TRUE)
   temp
 }
 
 #' deal with commas and carriage returns
 #'
 #' @description
-#' Puts escaped quotes around strings that contain commas or carriage returns.
+#' Puts nonsense markers around strings that contain commas or carriage returns.
 #' intended to imitate the behaviour of format_delim and prevent problems
-#' when these symbols are given syntactic meaning.
+#' when these symbols are given syntactic meaning. Also deals with escaping
+#' double and single quote
 #'
 #' @param x A character string
-#' @return Returns the string with escaped quotes
+#' @return Returns the string with nonsense markers where needed.
 fix_punctuation <- function(x) {
   # x is a character string. Some items might contain commas
-  comma_index <- grep("[,\n],", x, perl = TRUE)
-  x[comma_index] <- paste('\"', x[comma_index], '\"', sep = "")
+  # x is a character string. Some items might contain commas or carriage returns.
+  x <- gsub('\"', 'qu@t&', x, fixed = TRUE)
+  comma_index <- grep("[,\n]", x, perl = TRUE)
+  x[comma_index] <- paste('trogdor', x[comma_index], 'trogdor', sep = "")
   x
 }
 

--- a/man/add_dataframe.Rd
+++ b/man/add_dataframe.Rd
@@ -11,7 +11,7 @@ add_dataframe(
   na = "",
   graph = NULL,
   verbose = FALSE,
-  parallel = TRUE
+  parallel = FALSE
 )
 }
 \arguments{

--- a/man/fix_punctuation.Rd
+++ b/man/fix_punctuation.Rd
@@ -10,10 +10,11 @@ fix_punctuation(x)
 \item{x}{A character string}
 }
 \value{
-Returns the string with escaped quotes
+Returns the string with nonsense markers where needed.
 }
 \description{
-Puts escaped quotes around strings that contain commas or carriage returns.
+Puts nonsense markers around strings that contain commas or carriage returns.
 intended to imitate the behaviour of format_delim and prevent problems
-when these symbols are given syntactic meaning.
+when these symbols are given syntactic meaning. Also deals with escaping
+double and single quote
 }


### PR DESCRIPTION
Provided a workaround for the format_delim function in readr, which sometimes yields errors on large files.
